### PR TITLE
Fix handling of missing directories

### DIFF
--- a/import_atoms.sh
+++ b/import_atoms.sh
@@ -41,8 +41,13 @@ for JS in $JS_LIST
 do
     if [[ $JS != *_exports.js ]] && [[ $JS != *_ie.js ]] && [[ $JS != *build_atoms.js ]] && [[ $JS != *deps.js ]]
     then
-        echo "Importing Atom: $JS"
-        cp "$JS" "$DESTINATION_DIRECTORY"
+        if [ -e "$JS" ]
+        then
+            echo "Importing Atom: $JS"
+            cp "$JS" "$DESTINATION_DIRECTORY"
+        else
+            echo "Source does not exist: $JS"
+        fi
     fi
 done
 


### PR DESCRIPTION
Since setting `-e` in the the import script (https://github.com/appium/appium-atoms/commit/70281f2e9fc216f202ae53e38e3538f6b4e47f17) missing directories in our copy action have caused failures. This change accounts for this.
